### PR TITLE
Revert "Support Django v1.11 meddleware"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ MIDDLEWARE_CLASSES = (
 )
 ```
 
-If you are using Django 1.11, then add ```request_logging.middleware.LoggingMiddleware``` to your ```MIDDLEWARE``` instead of ```MIDDLEWARE_CLASSES```.
-
 And configure logging in your app:
 
 ```

--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -8,12 +8,6 @@ request_logger = logging.getLogger('django.request')
 
 
 class LoggingMiddleware(MiddlewareMixin):
-    def __call__(self, request):
-        self.process_request(request)
-        response = self.get_response(request)
-        self.process_response(request, response)
-
-        return response
 
     def process_request(self, request):
         request_logger.info(colorize("{} {}".format(request.method, request.get_full_path()), fg="cyan"))
@@ -51,4 +45,3 @@ class LoggingMiddleware(MiddlewareMixin):
             return "{0}\n...\n".format(msg[0:MAX_BODY_LENGTH])
         else:
             return msg
-


### PR DESCRIPTION
Reverts Rhumbix/django-request-logging#9

I found we don't need to override `__call__` because it already be implemented in [MiddlewareMixin](https://github.com/django/django/blob/90db4bb0d72e4731052bd33500840fff00834768/django/utils/deprecation.py#L85)

But the problem is `django-request-logging` install from pip have legacy code which didn't inherit `MiddlewareMixin`. I got `django-request-logging==0.4.6` from pip install. Maybe we should update this package on pip?

Sorry for my misunderstanding.