### PR TITLE
bug fix of __init__ missing args

### DIFF
--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -14,8 +14,8 @@ request_logger = logging.getLogger('django.request')
 
 
 class LoggingMiddleware(MiddlewareMixin):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.log_level = getattr(settings, SETTING_NAMES['log_level'], logging.DEBUG)
         if self.log_level not in [logging.NOTSET, logging.DEBUG, logging.INFO,


### PR DESCRIPTION
I'm really sorry for your inconvenience, but when I tried to use this package in my project, middleware fail to load.
This PR should fix the issue. I have tried this fix with pip install with editable mode (pip install -e) in my project and it looks like the issue resolved.
