### PR TITLE
Made multipart logging consistent

### DIFF
--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -20,7 +20,7 @@ request_logger = logging.getLogger('django.request')
 
 class Logger:
     def log(self, level, msg):
-        for line in str(msg).split('\n'):
+        for line in re.split(r'\r?\n', str(msg)):
             request_logger.log(level, line)
 
     def log_error(self, level, msg):
@@ -41,7 +41,7 @@ class ColourLogger(Logger):
         self._log(level, msg, self.log_error_colour)
 
     def _log(self, level, msg, colour):
-        for line in str(msg).split('\n'):
+        for line in re.split(r'\r?\n', str(msg)):
             line = colorize(line, fg=colour)
             request_logger.log(level, line)
 
@@ -107,7 +107,8 @@ class LoggingMiddleware(MiddlewareMixin):
         which searches for existance of "Content-Type" and capture of what type is this part.
         If it is an image or an application replace that content with "(binary data)" string.
         """
-        parts = str(body).split(self.boundary)
+        body_str = body if isinstance(body, str) else body.decode()
+        parts = body_str.split(self.boundary)
         last = len(parts) - 1
         for i, part in enumerate(parts):
             if 'Content-Type:' in part:

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 import io
 import unittest
+import re
 
 import logging
 import mock
@@ -135,7 +136,9 @@ class LogSettingsMaxLengthTestCase(BaseLogTestCase):
         body = DEFAULT_MAX_BODY_LENGTH * "0" + "1"
         request = factory.post("/somewhere", data={"file": body})
         middleware.process_request(request)
-        self._assert_logged(mock_log, str(request.body[:DEFAULT_MAX_BODY_LENGTH]))
+
+        request_body_str = request.body if isinstance(request.body, str) else request.body.decode()
+        self._assert_logged(mock_log, re.sub(r'\r?\n', '', request_body_str[:DEFAULT_MAX_BODY_LENGTH]))
         self._assert_not_logged(mock_log, body)
 
     @override_settings(REQUEST_LOGGING_MAX_BODY_LENGTH=150, REQUEST_LOGGING_DISABLE_COLORIZE=False)
@@ -146,7 +149,9 @@ class LogSettingsMaxLengthTestCase(BaseLogTestCase):
         body = 150 * "0" + "1"
         request = factory.post("/somewhere", data={"file": body})
         middleware.process_request(request)
-        self._assert_logged(mock_log, str(request.body[:150]))
+
+        request_body_str = request.body if isinstance(request.body, str) else request.body.decode()
+        self._assert_logged(mock_log, re.sub(r'\r?\n', '', request_body_str[:150]))
         self._assert_not_logged(mock_log, body)
 
     @override_settings(REQUEST_LOGGING_MAX_BODY_LENGTH='Not an int')


### PR DESCRIPTION
Fixed Python 2.7 failing test issue; it was due to body being `bytes` type, which in Python 2is just an alias to `str`, thus `str(body)` produced different behavior between 2 and 3 as Python 3 `str(bytes)` returned an informal representation such as `'b\'body\''`.