### PR TITLE
DRF none error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
 install:
   - pip install -r requirements-dev.txt
 script:

--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -94,15 +94,6 @@ class LoggingMiddleware(object):
             return self._log_cycle(request)
 
     def _skip_logging(self, request, reason):
-        method_path = "{} {}".format(request.method, request.get_full_path())
-        no_log_context = {
-            'args': (),
-            'kwargs': {
-                'extra': {
-                    'no_logging': reason
-                },
-            },
-        }
         self.logger.info("{} {} (reason: {})", request.method, request.get_full_path(), reason)
 
     def _log_cycle(self, request):

--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -87,29 +87,17 @@ class LoggingMiddleware(object):
         self.boundary = ''
 
     def __call__(self, request):
-        skip_logging_because = self._should_log_route(request)
-        if skip_logging_because:
-            return self._skip_logging(request, skip_logging_because)
-        else:
-            return self._log_cycle(request)
-
-    def _skip_logging(self, request, reason):
-        self.logger.info("{} {} (reason: {})", request.method, request.get_full_path(), reason)
-
-    def _log_cycle(self, request):
-        self.process_request(request)
-        response = self.get_response(request)
-        self.process_response(request, response)
+        self.process_request( request )
+        response = self.get_response( request )
+        self.process_response( request, response )
         return response
 
     def process_request(self, request):
-        method_path = "{} {}".format(request.method, request.get_full_path())
-        no_logging = self._should_log_route(request)
-
-        logging_context = self._get_logging_context(request, None)
-        self.logger.log(logging.INFO, method_path, logging_context)
-        self._log_request_headers(request, no_logging, logging_context)
-        self._log_request_body(request, no_logging, logging_context)
+        skip_logging_because = self._should_log_route(request)
+        if skip_logging_because:
+            return self._skip_logging_request(request, skip_logging_because)
+        else:
+            return self._log_request(request)
 
     def _should_log_route(self, request):
         try:
@@ -123,7 +111,9 @@ class LoggingMiddleware(object):
         # This is for "django rest framework"
         if hasattr(view, 'cls'):
             if hasattr(view, 'actions'):
-                func = getattr(view.cls, view.actions[method], None)
+                actions = view.actions
+                if hasattr(actions, method):
+                    func = getattr(view.cls, view.actions[method], None)
             else:
                 func = getattr(view.cls, method, None)
         elif hasattr(view, 'view_class'):
@@ -132,25 +122,42 @@ class LoggingMiddleware(object):
         no_logging = getattr(func, NO_LOGGING_ATTR, None)
         return no_logging
 
-    def _log_request_headers(self, request, no_logging, logging_context):
+    def _skip_logging_request(self, request, reason):
+        method_path = "{} {}".format(request.method, request.get_full_path())
+        no_log_context = {
+            'args': (),
+            'kwargs': {
+                'extra': {
+                    'no_logging': reason
+                },
+            },
+        }
+        self.logger.log(logging.INFO, method_path + " (not logged because '" + reason + "')", no_log_context)
+
+    def _log_request(self, request):
+        method_path = "{} {}".format(request.method, request.get_full_path())
+
+        logging_context = self._get_logging_context(request, None)
+        self.logger.log(logging.INFO, method_path, logging_context)
+        self._log_request_headers(request, logging_context)
+        self._log_request_body(request, logging_context)
+
+    def _log_request_headers(self, request, logging_context):
         headers = {k: v for k, v in request.META.items() if k.startswith('HTTP_')}
 
         if headers:
             self.logger.log(self.log_level, headers, logging_context)
 
-    def _log_request_body(self, request, no_logging, logging_context):
+    def _log_request_body(self, request, logging_context):
         if request.body:
-            if no_logging is not None:
-                self.logger.log(self.log_level, no_logging, logging_context)
+            content_type = request.META.get('CONTENT_TYPE', '')
+            is_multipart = content_type.startswith('multipart/form-data')
+            if is_multipart:
+                self.boundary = '--' + content_type[30:]  # First 30 characters are "multipart/form-data; boundary="
+            if is_multipart:
+                self._log_multipart(self._chunked_to_max(request.body), logging_context)
             else:
-                content_type = request.META.get('CONTENT_TYPE', '')
-                is_multipart = content_type.startswith('multipart/form-data')
-                if is_multipart:
-                    self.boundary = '--' + content_type[30:]  # First 30 characters are "multipart/form-data; boundary="
-                if is_multipart:
-                    self._log_multipart(self._chunked_to_max(request.body), logging_context)
-                else:
-                    self.logger.log(self.log_level, self._chunked_to_max(request.body), logging_context)
+                self.logger.log(self.log_level, self._chunked_to_max(request.body), logging_context)
 
     def process_response(self, request, response):
         resp_log = "{} {} - {}".format(request.method, request.get_full_path(), response.status_code)
@@ -169,7 +176,6 @@ class LoggingMiddleware(object):
         """
         Returns a map with args and kwargs to provide additional context to calls to logging.log().
         This allows the logging context to be created per process request/response call.
-
         """
         return {
             'args': (),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 mock==2.0.0
 django==1.11.8
 coverage==4.4.2
+djangorestframework==3.8.2

--- a/test_urls.py
+++ b/test_urls.py
@@ -2,8 +2,7 @@ from django.conf.urls import url, include
 from django.http import HttpResponse
 from django.views import View
 from request_logging.decorators import no_logging
-from rest_framework import (viewsets, mixins)
-from rest_framework import routers
+from rest_framework import viewsets, routers
 
 
 def general_resource(request):

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.conf.urls import url
 from django.http import HttpResponse
 from django.views import View
 from request_logging.decorators import no_logging

--- a/test_urls.py
+++ b/test_urls.py
@@ -38,6 +38,7 @@ class UnannotatedDRF(viewsets.ReadOnlyModelViewSet):
     def list(self, request):
         return HttpResponse(status=200, body="DRF Unannotated")
 
+
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r"widgets", UnannotatedDRF, base_name="widget")
 

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,13 +1,19 @@
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.http import HttpResponse
 from django.views import View
 from request_logging.decorators import no_logging
+from rest_framework import (viewsets, mixins)
+from rest_framework import routers
 
 
 def general_resource(request):
     return HttpResponse(status=200, body='Generic repsonse entity')
 
+
 class TestView(View):
+    def get(self):
+        return HttpResponse(status=200)
+
     @no_logging()
     def post(self, request):
         return HttpResponse(status=200)
@@ -28,10 +34,18 @@ def dont_log_empty_response_body(request):
     return HttpResponse(status=201)
 
 
+class UnannotatedDRF(viewsets.ReadOnlyModelViewSet):
+    @no_logging("DRF explicit annotation")
+    def list(self, request):
+        return HttpResponse(status=200, body="DRF Unannotated")
+
+router = routers.SimpleRouter(trailing_slash=False)
+router.register(r"widgets", UnannotatedDRF, base_name="widget")
+
 urlpatterns = [
     url(r'^somewhere$', general_resource),
     url(r'^test_class$', TestView.as_view()),
     url(r'^test_func$', view_func),
     url(r'^test_msg$', view_msg),
-    url(r'^dont_log_empty_response_body', dont_log_empty_response_body),
-]
+    url(r'^dont_log_empty_response_body$', dont_log_empty_response_body),
+] + router.urls


### PR DESCRIPTION
In a suite we found a test case posting to a nonexistent DRF resource would raise a puzzling error attempting to lookup the method in the `actions` attribute.  This was discovered because we didn't eat all exceptions while attempting to locate attributes.

The fix was simple: check if the action exists.

The remainder is cleaning up the library and adding more test cases.  Now pulls in DRF for testing.