### PR TITLE
Do not log 400-499 responses as ERROR

### DIFF
--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -163,7 +163,7 @@ class LoggingMiddleware(object):
         resp_log = "{} {} - {}".format(request.method, request.get_full_path(), response.status_code)
         logging_context = self._get_logging_context(request, response)
 
-        if response.status_code in range(400, 600):
+        if response.status_code in range(500, 600):
             self.logger.log_error(logging.INFO, resp_log, logging_context)
             self._log_resp(logging.ERROR, response, logging_context)
         else:


### PR DESCRIPTION
400-499 represent client errors and not server errors, therefore they should not log as errors.

Fixes #42 