### PR TITLE
Configurable 4xx level

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Most of times you don't have to care about these details. But in case you need t
 * If HTTP status code is between 400 - 599, URIs are logged at ERROR level, otherwise they are logged at INFO level.
 * If HTTP status code is between 400 - 599, data are logged at ERROR level, otherwise they are logged at DEBUG level.
 
+See `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL` setting to override this. 
+
+
 A `no_logging` decorator is included for views with sensitive data.
 
 ## Django settings
@@ -63,3 +66,6 @@ This legacy setting will still available, but you should't use this setting anym
 We keep this settings for backward compatibility. 
 ### REQUEST_LOGGING_MAX_BODY_LENGTH
 By default, max length of a request body and a response content is cut to 50000 characters.
+### REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL
+By default, HTTP status codes between 400 - 499 are logged at ERROR level.  You can set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logger.WARNING` (etc) to override this.
+If you set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logger.INFO` they will be logged the same as normal requests.


### PR DESCRIPTION
I've expanded on #43  to make the logging level of HTTP 400-499 responses configurable.  Defaults to current behaviour (logging as per 5xx ERRORs).

adds setting `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL` (default = `logging.ERROR`)

Resolves #42 