### PR TITLE
no_logging decorator respects dynamic urlconf

### DIFF
--- a/test_urls_alternate.py
+++ b/test_urls_alternate.py
@@ -1,0 +1,13 @@
+from django.conf.urls import url
+from django.http import HttpResponse
+from request_logging.decorators import no_logging
+
+
+@no_logging()
+def view_func(request):
+    return HttpResponse(status=200, body="view_func with no logging")
+
+
+urlpatterns = [
+    url(r'^test_route$', view_func),
+]

--- a/tests.py
+++ b/tests.py
@@ -380,6 +380,14 @@ class DecoratorTestCase(BaseLogTestCase):
         self._assert_not_logged(mock_log, NO_LOGGING_MSG)
         self._assert_logged(mock_log, 'Empty response body')
 
+    def test_no_logging_alternate_urlconf(self, mock_log):
+        body = u"some super secret body"
+        request = self.factory.post("/test_route", data={"file": body})
+        request.urlconf = 'test_urls_alternate'
+        self.middleware.process_request(request)
+        self._assert_not_logged(mock_log, body)
+        self._assert_logged(mock_log, NO_LOGGING_MSG)
+
     def test_still_logs_verb(self, mock_log):
         body = u"our work of art"
         request = self.factory.post("/dont_log_empty_response_body", data={"file": body})


### PR DESCRIPTION
The `no_logging` decorator will now try to use `request.urlconf`, if set by middleware or application code, when resolving the route. If `request.urlconf` has not been set, then the route resolution behaves as normal.