### PR TITLE
UnicodeDecodeError : Always try to decode multipart body

### DIFF
--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -221,7 +221,7 @@ class LoggingMiddleware(object):
         This function will log "(multipart/form)" if body can't be decoded by utf-8.
         """
         try:
-            body_str = body if isinstance(body, str) else body.decode()
+            body_str = body.decode()
         except UnicodeDecodeError:
             self.logger.log(self.log_level, "(multipart/form)", logging_context)
             return

--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,6 @@ class LogTestCase(BaseLogTestCase):
         self.middleware.process_request(request)
         self._assert_logged(mock_log, "(binary data)")
 
-    @unittest.skipIf(sys.version_info < (3, 0), "This issue won't happen on python 2")
     def test_request_jpeg_logged(self, mock_log):
         body = b'--BoUnDaRyStRiNg\r\nContent-Disposition: form-data; name="file"; filename="campaign_carousel_img.jp' \
                b'g"\r\nContent-Type: image/jpeg\r\n\r\n\xff\xd8\xff\xe1\x00\x18Exif\x00\x00II*\x00\x08\x00\x00\x00' \
@@ -132,7 +131,6 @@ class LogTestCase(BaseLogTestCase):
         self._assert_logged(mock_log, "test_headers")
         self._assert_logged(mock_log, "HTTP_USER_AGENT")
 
-    @unittest.skipIf(sys.version_info < (3, 0), "This issue won't happen on python 2")
     def test_call_jpeg_logged(self, mock_log):
         body = b'--BoUnDaRyStRiNg\r\nContent-Disposition: form-data; name="file"; filename="campaign_carousel_img.jp' \
                b'g"\r\nContent-Type: image/jpeg\r\n\r\n\xff\xd8\xff\xe1\x00\x18Exif\x00\x00II*\x00\x08\x00\x00\x00' \


### PR DESCRIPTION
Fixes #28 

Always call `body.decode()` on a multipart request. This fixes the UnicodeDecodeError when sending a request with a binary file such as a jpeg.

I took the liberty of removing the `@unittest.skipIf`, since the problem does happen on Python 2.

One of the problems now is that the whole body is reduced to `(multipart/form)` if any of the request parameters are binary, but it seems this behavior was already present before.