### PR TITLE
Prevent sensative information from being logged

### DIFF
--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -173,7 +173,8 @@ class LoggingMiddleware(object):
             if is_multipart:
                 self._log_multipart(self._chunked_to_max(request.body), logging_context)
             else:
-                self.logger.log(self.log_level, SafeExceptionReporterFilter().get_post_parameters(request), logging_context)
+                safe_body = SafeExceptionReporterFilter().get_post_parameters(request).dict()
+                self.logger.log(self.log_level, self._chunked_to_max(str(safe_body)), logging_context)
 
     def process_response(self, request, response):
         resp_log = "{} {} - {}".format(request.method, request.get_full_path(), response.status_code)

--- a/tests.py
+++ b/tests.py
@@ -59,6 +59,7 @@ class MissingRoutes(BaseLogTestCase):
         body = u"some body"
         request = self.factory.post("/a-missing-route-somewhere", data={"file": body})
         self.middleware.process_request(request)
+        self.middleware.process_body(request)
         self._assert_logged(mock_log, body)
 
 
@@ -79,6 +80,7 @@ class LogTestCase(BaseLogTestCase):
         body = u"some body"
         request = self.factory.post("/somewhere", data={"file": body})
         self.middleware.process_request(request)
+        self.middleware.process_body(request)
         self._assert_logged(mock_log, body)
 
     def test_request_binary_logged(self, mock_log):
@@ -86,6 +88,7 @@ class LogTestCase(BaseLogTestCase):
         datafile = io.StringIO(body)
         request = self.factory.post("/somewhere", data={"file": datafile})
         self.middleware.process_request(request)
+        self.middleware.process_body(request)
         self._assert_logged(mock_log, "(binary data)")
 
     def test_request_jpeg_logged(self, mock_log):
@@ -96,6 +99,7 @@ class LogTestCase(BaseLogTestCase):
         datafile = io.BytesIO(body)
         request = self.factory.post("/somewhere", data={"file": datafile})
         self.middleware.process_request(request)
+        self.middleware.process_body(request)
         self._assert_logged(mock_log, "(multipart/form)")
 
     def test_request_headers_logged(self, mock_log):
@@ -315,7 +319,7 @@ class LogSettingsMaxLengthTestCase(BaseLogTestCase):
 
         body = DEFAULT_MAX_BODY_LENGTH * "0" + "1"
         request = factory.post("/somewhere", data={"file": body})
-        middleware.process_request(request)
+        middleware.process_body(request)
 
         request_body_str = request.body if isinstance(request.body, str) else request.body.decode()
         self._assert_logged(mock_log, re.sub(r'\r?\n', '', request_body_str[:DEFAULT_MAX_BODY_LENGTH]))
@@ -328,7 +332,7 @@ class LogSettingsMaxLengthTestCase(BaseLogTestCase):
 
         body = 150 * "0" + "1"
         request = factory.post("/somewhere", data={"file": body})
-        middleware.process_request(request)
+        middleware.process_body(request)
 
         request_body_str = request.body if isinstance(request.body, str) else request.body.decode()
         self._assert_logged(mock_log, re.sub(r'\r?\n', '', request_body_str[:150]))


### PR DESCRIPTION
This change uses the `SafeExceptionReportFilter` when logging the body as outlined in issue #64 and also fixes #64.  I have done some basic testing with a simple django application which uses the `sensitive_post_parameters` decorator and seen that the fields are filtered out.

One caveat is that this does change the behavior of logging the body, the decorator that specifies the variables to filter doesn't run until the view is called so logging the body needs to come after `self.get_response( request )` otherwise it'll still have sensitive information in plaintest.  Here's an example of what I get using this now on an application using allauth

` {'csrfmiddlewaretoken': 'xAXmfqD1PYMttgqseguGHh1FQxWPkhxVPu07BHvXA9MICiNtSJJbU1pXrkfzVTFr', 'login': 'sean@example.com', 'password': '********************', 'next': '/'}`

Previously the password would have been revealed.  Also because `SafeExceptionReportFilter` is based on request.POST instead of request.body I have left a fallback in case that doesn't exist, I don't think that'll ever get hit though.