### PR TITLE
asterik out sensitive headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Most of times you don't have to care about these details. But in case you need t
 * If HTTP status code is between 400 - 599, URIs are logged at ERROR level, otherwise they are logged at INFO level.
 * If HTTP status code is between 400 - 599, data are logged at ERROR level, otherwise they are logged at DEBUG level.
 
-See `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL` setting to override this. 
+See `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL` setting to override this.
 
 
 A `no_logging` decorator is included for views with sensitive data.
@@ -63,9 +63,11 @@ By default, data will log in DEBUG level, you can change to other valid level (E
 If you want to log into log file instead of console, you may want to remove ANSI color. You can set `REQUEST_LOGGING_ENABLE_COLORIZE=False` to disable colorize.
 ### REQUEST_LOGGING_DISABLE_COLORIZE (Deprecated)
 This legacy setting will still available, but you should't use this setting anymore. You should use `REQUEST_LOGGING_ENABLE_COLORIZE` instead.
-We keep this settings for backward compatibility. 
+We keep this settings for backward compatibility.
 ### REQUEST_LOGGING_MAX_BODY_LENGTH
 By default, max length of a request body and a response content is cut to 50000 characters.
 ### REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL
 By default, HTTP status codes between 400 - 499 are logged at ERROR level.  You can set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logging.WARNING` (etc) to override this.
 If you set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logging.INFO` they will be logged the same as normal requests.
+### REQUEST_LOGGING_SENSITIVE_HEADERS
+By default, all the HTTP headers are logged including sensitive information like authorization tokens. The value of the headers defined in this settings will be replaced with `'*****'` to hide the sensitive information while logging. E.g. `REQUEST_LOGGING_SENSITIVE_HEADERS = ['HTTP_AUTHORIZATION', 'HTTP_USER_AGENT']`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ See `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL` setting to override this.
 
 A `no_logging` decorator is included for views with sensitive data.
 
+By default, value of Http headers `HTTP_AUTHORIZATION` and `HTTP_PROXY_AUTHORIZATION` are replaced wih `*****`. You can use `REQUEST_LOGGING_SENSITIVE_HEADERS` setting to override this default behaviour with your list of sensitive headers.
+
 ## Django settings
 You can customized some behaves of django-request-logging by following settings in Django `settings.py`.
 ### REQUEST_LOGGING_DATA_LOG_LEVEL
@@ -70,4 +72,4 @@ By default, max length of a request body and a response content is cut to 50000 
 By default, HTTP status codes between 400 - 499 are logged at ERROR level.  You can set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logging.WARNING` (etc) to override this.
 If you set `REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL=logging.INFO` they will be logged the same as normal requests.
 ### REQUEST_LOGGING_SENSITIVE_HEADERS
-By default, all the HTTP headers are logged including sensitive information like authorization tokens. The value of the headers defined in this settings will be replaced with `'*****'` to hide the sensitive information while logging. E.g. `REQUEST_LOGGING_SENSITIVE_HEADERS = ['HTTP_AUTHORIZATION', 'HTTP_USER_AGENT']`
+The value of the headers defined in this settings will be replaced with `'*****'` to hide the sensitive information while logging. E.g. `REQUEST_LOGGING_SENSITIVE_HEADERS = ['HTTP_AUTHORIZATION', 'HTTP_USER_AGENT']`

--- a/request_logging/middleware.py
+++ b/request_logging/middleware.py
@@ -14,6 +14,7 @@ DEFAULT_LOG_LEVEL = logging.DEBUG
 DEFAULT_HTTP_4XX_LOG_LEVEL = logging.ERROR
 DEFAULT_COLORIZE = True
 DEFAULT_MAX_BODY_LENGTH = 50000  # log no more than 3k bytes of content
+DEFAULT_SENSITIVE_HEADERS = ['HTTP_AUTHORIZATION', 'HTTP_PROXY_AUTHORIZATION']
 SETTING_NAMES = {
     'log_level': 'REQUEST_LOGGING_DATA_LOG_LEVEL',
     'http_4xx_log_level': 'REQUEST_LOGGING_HTTP_4XX_LOG_LEVEL',
@@ -67,7 +68,7 @@ class LoggingMiddleware(object):
 
         self.log_level = getattr(settings, SETTING_NAMES['log_level'], DEFAULT_LOG_LEVEL)
         self.http_4xx_log_level = getattr(settings, SETTING_NAMES['http_4xx_log_level'], DEFAULT_HTTP_4XX_LOG_LEVEL)
-        self.sensitive_headers = getattr(settings, SETTING_NAMES['sensitive_headers'], [])
+        self.sensitive_headers = getattr(settings, SETTING_NAMES['sensitive_headers'], DEFAULT_SENSITIVE_HEADERS)
         if not isinstance(self.sensitive_headers, list):
             raise ValueError(
                 "{} should be list. {} is not list.".format(SETTING_NAMES['sensitive_headers'], self.sensitive_headers)


### PR DESCRIPTION
This PR would solve the issues concerning the expose of sensitive headers like  Authorization while logging. The sensitive headers can be asteriked out while logging by using the setting `REQUEST_LOGGING_SENSITIVE_HEADERS`. Solves the concerns raised in issue #38 and #59 . 
While `no_logging` decorator can be used to exclude the entire view, this setting will come handy to hide the value of certain headers. One use case would be excluding AUTHORIZATION header when JWTs are used.