### PR TITLE
Added silent flag which completely disables the logging of an endpoint

### DIFF
--- a/request_logging/decorators.py
+++ b/request_logging/decorators.py
@@ -1,9 +1,10 @@
 from functools import wraps
-from .middleware import NO_LOGGING_ATTR, NO_LOGGING_MSG
+from .middleware import NO_LOGGING_ATTR, NO_LOGGING_MSG_ATTR, NO_LOGGING_MSG
 
 
-def no_logging(msg=None):
+def no_logging(msg=None, silent=False):
     def wrapper(func):
-        setattr(func, NO_LOGGING_ATTR, msg if msg else NO_LOGGING_MSG)
+        setattr(func, NO_LOGGING_ATTR, True)
+        setattr(func, NO_LOGGING_MSG_ATTR, (msg if msg else NO_LOGGING_MSG) if not silent else None)
         return func
     return wrapper

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ django>=1.11.20,<2.0 ; python_version < '3.0'
 django>=1.11.20,<3.0 ; python_version >= '3.0' and python_version < '3.6'
 django>=2.0,<3.1.0 ; python_version >= '3.6'
 coverage==4.4.2
-djangorestframework==3.8.2 ; python_version < '3.0'
-djangorestframework==3.11.0 ; python_version > '3.0'
+djangorestframework==3.8.2 ; python_version <= '3.4'
+djangorestframework==3.11.0 ; python_version >= '3.5'

--- a/test_urls.py
+++ b/test_urls.py
@@ -4,9 +4,10 @@ from django.conf.urls import url
 from django.http import HttpResponse
 from django.views import View
 from request_logging.decorators import no_logging
-from rest_framework import viewsets, routers
+from rest_framework import viewsets, routers, VERSION
 
-IS_PYTHON_27 = sys.version_info[0] < 3
+# DRF 3.8.2 is used in python versions 3.4 and older, which needs special handling
+IS_DRF_382 = sys.version_info <= (3, 4)
 
 
 def general_resource(request):
@@ -51,7 +52,7 @@ class UnannotatedDRF(viewsets.ModelViewSet):
 
 
 router = routers.SimpleRouter(trailing_slash=False)
-if IS_PYTHON_27:
+if IS_DRF_382:
     last_arguments = {
         "base_name": "widgets"
     }

--- a/test_urls.py
+++ b/test_urls.py
@@ -31,6 +31,9 @@ def view_func(request):
 def view_msg(request):
     return HttpResponse(status=200, body="view_msg with no logging with a custom reason why")
 
+@no_logging(silent=True)
+def dont_log_silent(request):
+    return HttpResponse(status=200, body="view_msg with silent flag set")
 
 @no_logging('Empty response body')
 def dont_log_empty_response_body(request):
@@ -65,4 +68,5 @@ urlpatterns = [
     url(r'^test_func$', view_func),
     url(r'^test_msg$', view_msg),
     url(r'^dont_log_empty_response_body$', dont_log_empty_response_body),
+    url(r'^dont_log_silent$', dont_log_silent),
 ] + router.urls

--- a/tests.py
+++ b/tests.py
@@ -405,6 +405,14 @@ class DecoratorTestCase(BaseLogTestCase):
         self._assert_not_logged(mock_log, NO_LOGGING_MSG)
         self._assert_logged(mock_log, 'Custom message')
 
+    def test_no_logging_decorator_silent(self, mock_log):
+        body = u"some super secret body"
+        request = self.factory.post("/dont_log_silent", data={"file": body})
+        self.middleware.process_request(request)
+        self._assert_not_logged(mock_log, body)
+        self._assert_not_logged(mock_log, NO_LOGGING_MSG)
+        self._assert_not_logged(mock_log, 'not logged because')
+
     def test_no_logging_empty_response_body(self, mock_log):
         body = u"our work of art"
         request = self.factory.post("/dont_log_empty_response_body", data={"file": body})


### PR DESCRIPTION
Added a "silent" flag in the no_logging decorator that completely silences the output of a log entry. This is useful for cases of health checks (or other routine/redundant calls) which fill the logs with useless entries.

The changes are completely backwards compatible. They pass the current tests and an added one that tests the new functionality