### PR TITLE
travis: drop python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7


### PR DESCRIPTION
As it's not supported by coverage anymore:

Collecting coverage==5.2.1 (from -r requirements-dev.txt (line 6))
  Could not find a version that satisfies the requirement coverage==5.2.1